### PR TITLE
WIP Refactor retry()

### DIFF
--- a/R/kms.R
+++ b/R/kms.R
@@ -1,28 +1,28 @@
 #' Retry the query up to 3 times on failure
 #' @param cmd expression
-#' @param retries number of previous retries
+#' @param retries number of retries
 #' @keywords internal
 #' @importFrom futile.logger flog.error
-retry <- function(cmd, retries = 0) {
-
+retry <- function(cmd, retries = 3) {
     cmd <- substitute(cmd)
-    res <- tryCatch(eval(cmd, envir = parent.frame()), error = function(e) e)
+    backoff <- 2
+    
+    repeat {
+      res <- tryCatch(eval(cmd, envir = parent.frame()), error = function(e) e)
 
-    mc <- match.call()
-    if (is.null(mc$retries)) mc$retries <- 0
-    mc$retries <- mc$retries + 1
-    if (mc$retries > 3) {
-        stop('Tried too many times, giving up')
-    }
-
-    if (inherits(res, 'error')) {
+      if (!inherits(res, 'error')) {
+        return(res)
+      } else if(retries > 0) {
         flog.error('Retrying query due to AWS error: %s', res$message)
-        Sys.sleep(2 + (mc$retries - 1) * 10)
-        res <- eval(mc, envir = parent.frame())
+        Sys.sleep(backoff)
+        retries <- retries - 1
+        backoff <- backoff + 10
+      } else {
+        stop('Tried too many times, giving up')         
+      }                      
     }
-
-    res
-
+                      
+    stop("Not possible to reach here")
 }
 
 


### PR DESCRIPTION
`retry()` would be useful in the parent AWR package so I/"we" could reuse it on other AWS services - but first - I don't think we really need or want recursion / NSE recursion in there. Also it would be nice to count down from `retries` rather than up to hardcoded `3` . Haven't tested this yet.